### PR TITLE
Change from .py to .yaml and read from command line 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,5 @@
 [![Build Status](https://travis-ci.org/popperized/open-comp-rsc-popper.svg?branch=master)](https://travis-ci.org/popperized/open-comp-rsc-popper)
 
-Example project to demonstrate a concept of how to share computational research openly meeting important reproducibility demands.
+Example project to demonstrate a concept of how to share computational research openly meeting important reproducibility demands. Uses Sumatra, Docker and the Popper framework.
 
-To access the project, first make sure you have Docker installed. Then open a terminal (on Windows your Docker environment), change into this directory and run the script access_lab_YOUR-OS.sh, replacing YOUR-OS with linux, mac or windows7.
-
-For example on Linux
-
-$ cd ~/open-comp-rsc
-$ source access_lab_linux.sh
-
-To view the lab notebook open your browser and navigate to the address as instructed from the terminal.
-
-To reproduce data, try for example repeating the simulation with the label 18e35e47 with the command
-
-$ smt repeat 18e35e47
-
-For more documentation see also http://felix11h.github.io/blog/open-comp-rsc-concept. In case of problems, please contact felix11h.dev@gmail.com. 
-
-Originally uploaded at Zenodo, DOI: 10.5281/zenodo.1145678. This work was supported by the Open Science Fellows program: https://en.wikiversity.org/wiki/Wikimedia_Deutschland/Open_Science_Fellows_Program
-
+To access the project, first make sure you have Docker installed. Then open a terminal (on Windows your Docker environment), change into this directory and run the script `access_lab.sh`.

--- a/comp/generate_random_numbers.py
+++ b/comp/generate_random_numbers.py
@@ -1,13 +1,15 @@
 
 import numpy as np
-import random
+import sys, yaml, random
 
-from params import n, low_bound, up_bound, n_sets, seed
+prm = yaml.load(open(sys.argv[1]))
 
-np.random.seed(seed)
-random.seed(seed)
+np.random.seed(prm['seed'])
+random.seed(prm['seed'])
 
 
-for k in range(n_sets):
-    data = np.random.uniform(low=low_bound, high=up_bound, size=n)
+for k in range(prm['n_sets']):
+    data = np.random.uniform(low=prm['low_bound'],
+                             high=prm['up_bound'],
+                             size=prm['n_sets'])
     np.save('comp/data/original-set-' + str(k), data)

--- a/comp/generate_random_numbers.sh
+++ b/comp/generate_random_numbers.sh
@@ -9,4 +9,5 @@ smt run \
   --main=comp/generate_random_numbers.py \
   --reason='generate random numbers' \
   --label=$LABEL \
-  --tag=generate comp/params.py
+  --tag=generate \
+  comp/params.yaml


### PR DESCRIPTION
This now lets `smt repeat` pass even when `params.yaml` was changed. 

I'm still thinking where to store the .yaml files. They can't go into main repo as Sumatra would require a new code version with every change of the parameter file. I considered including in the .smt repo (https://github.com/popperized/open-comp-rsc-popper-smt). I think this could be a good solution, making the structure 

```
├── comp
│   ├── ...
├── params
│   ├── ...
├── popper_pipeline
│   ├── ...
├── .popper.yml
├── .smt
└── .git
```

I want to include include .yaml files for each .sh computations, as otherwise they can't be run outside of `smt repeat` with knowing how to write the parameter file [#1](https://github.com/popperized/open-comp-rsc-popper-smt/issues/1).
